### PR TITLE
Don't swallow more detailed error messages from PayPal

### DIFF
--- a/paypal.go
+++ b/paypal.go
@@ -51,7 +51,7 @@ type PayPalError struct {
 func (e *PayPalError) Error() string {
 	var message string
 	if len(e.ErrorCode) != 0 && len(e.ShortMessage) != 0 {
-		message = "PayPal Error " + e.ErrorCode + ": " + e.ShortMessage
+		message = "PayPal Error " + e.ErrorCode + ": " + e.ShortMessage + " - " + e.LongMessage
 	} else if len(e.Ack) != 0 {
 		message = e.Ack
 	} else {


### PR DESCRIPTION
Small commit that shows the extended error information from PayPal.  For me, it gave me the solution to the problem.  I had to call PayPal to turn on their Digital Goods API for the account.

Also submitted changes based on goimports/gofmt which is the standard for how .go files should be formatted.
